### PR TITLE
Add CA Support

### DIFF
--- a/authorizer/index.js
+++ b/authorizer/index.js
@@ -2,9 +2,6 @@ const https = require('https');
 const querystring = require('querystring');
 const {getSecret} = require('../utils/getSecret.js');
 
-// TODO: remove this and get the server a proper certificate
-// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 exports.handler = async (event) => {
   const secret = await getSecret('Keycloak-Authorizer');
   const options = generateOptionsWithAuthHeader(secret.username, secret.password);
@@ -13,10 +10,6 @@ exports.handler = async (event) => {
     // the mulitline ca file with contain \n characters which will need to be
     // changed back into actual newline chars.  This oddity performs that function.
     options.ca = process.env.CA_FILE.split('\n').join('\n');
-  }
-
-  if (process.env.REJECT_UNAUTHORIZED === 'false') {
-    options.rejectUnathorized = false;
   }
 
   return new Promise((accept, reject) => {

--- a/authorizer/index.js
+++ b/authorizer/index.js
@@ -6,12 +6,6 @@ exports.handler = async (event) => {
   const secret = await getSecret('Keycloak-Authorizer');
   const options = generateOptionsWithAuthHeader(secret.username, secret.password);
 
-  if (process.env.CA_FILE) {
-    // the mulitline ca file with contain \n characters which will need to be
-    // changed back into actual newline chars.  This oddity performs that function.
-    options.ca = process.env.CA_FILE.split('\n').join('\n');
-  }
-
   return new Promise((accept, reject) => {
     const req = https.request(options, (resp) => {
       let data = '';
@@ -58,7 +52,7 @@ exports.handler = async (event) => {
 function generateOptionsWithAuthHeader(username, password) {
   const authHeader =
     Buffer.from(`${username}:${password}`).toString('base64');
-  return {
+  const options = {
     hostname: process.env.OAUTH_SERVER_HOST,
     port: process.env.OAUTH_SERVER_PORT,
     path: process.env.OAUTH_SERVER_PATH,
@@ -69,6 +63,14 @@ function generateOptionsWithAuthHeader(username, password) {
       'X-Forwarded-Host': process.env.FORWARDED_HOST || 'testing.icaredata.org',
     },
   };
+
+  if (process.env.CA_FILE) {
+    // the mulitline ca file with contain \n characters which will need to be
+    // changed back into actual newline chars.  This oddity performs that function.
+    options.ca = [process.env.CA_FILE.split('\n').join('\n')];
+  }
+
+  return options;
 }
 
 /**

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -30,17 +30,19 @@ function generateOptions(params) {
       'X-Forwarded-Host': process.env.FORWARDED_HOST || 'testing.icaredata.org',
     },
   };
+
+  if (process.env.CA_FILE) {
+    // the mulitline ca file with contain \n characters which will need to be
+    // changed back into actual newline chars.  This oddity performs that function.
+    options.ca = [process.env.CA_FILE.split('\n').join('\n')];
+  }
+
   return options;
 };
 
 exports.handler = async (event) => {
   const options = generateOptions(event.queryStringParameters);
 
-  if (process.env.CA_FILE) {
-    // the mulitline ca file with contain \n characters which will need to be
-    // changed back into actual newline chars.  This oddity performs that function.
-    options.ca = process.env.CA_FILE.split('\n').join('\n');
-  }
 
   return new Promise((accept, reject) => {
     const req = https.request(options, (resp) => {

--- a/proxy/index.js
+++ b/proxy/index.js
@@ -1,7 +1,6 @@
 const https = require('https');
 const querystring = require('querystring');
 const _ = require('lodash');
-// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 /**
  * Generate a url joining env-specific server path and provided params
@@ -41,10 +40,6 @@ exports.handler = async (event) => {
     // the mulitline ca file with contain \n characters which will need to be
     // changed back into actual newline chars.  This oddity performs that function.
     options.ca = process.env.CA_FILE.split('\n').join('\n');
-  }
-
-  if (process.env.REJECT_UNAUTHORIZED === 'false') {
-    options.rejectUnathorized = false;
   }
 
   return new Promise((accept, reject) => {


### PR DESCRIPTION
This PR builds off work that @rdingwell did to add support for a CA certificate in the Lambdas. It also removes the NODE_TLS_REJECT_UNAUTHORIZED environment variable from the code because it has been added to the Lambda consoles instead.

This code is implemented so that if/when we have a CA certificate, we can provide it in the CA_FILE environment variable. We right now don't have a certificate that is valid, unfortunately, but nonetheless the code as written should still stand as this is the way to add a certificate to an https request.

This code is deployed in our dev environment, using the NODE_TLS_REJECT_UNAUTHORIZED environment variable, and currently not using the CA_FILE or FORWARDED_HOST fields in this environment. To test effectively, run the client and verify that you can authenticate successfully. Any result returned from the database indicates a success (whether a success or constraint violation). 

**NOTE** Please do not merge after two approvals. There is a possibility that @rdingwell and/or I make a certificate that we want to try with this, so in case we need to make any additional changes before merge, just leave this here until we confirm.