### PR TITLE
Change success response to callback rather than return

### DIFF
--- a/process-message/index.js
+++ b/process-message/index.js
@@ -149,7 +149,7 @@ exports.handler = async (bundle, context, callback) => {
   dbConnection.destroy();
 
   if (getResponseCode(response) === 'ok') {
-    return response;
+    callback(null, response);
   }
   callback(response);
 };


### PR DESCRIPTION
The success response for the messaging Lambda used to be a `return` rather than a callback. This makes it a callback to be in line with the rest of the Lambda results.

It's been uploaded to AWS in dev and prod. Can be tested by just verifying that you're still able to get a successful 200 response for uploading a bundle.