### PR TITLE
Remove errors that cause potential crashes with incomplete data

### DIFF
--- a/extraction/index.js
+++ b/extraction/index.js
@@ -72,9 +72,11 @@ const getConditionFromReference = (bundle, refArray) => {
       false,
   ).find((r) => {
     if (reference.startsWith('urn:uuid:')) {
-      return r.id === reference.split(':')[2];
+      const referenceId = reference.split(':')[2];
+      return r.id === referenceId || (r.identifier && r.identifier.some(id => id.value === referenceId));
     } else if (reference.includes('/')) {
-      return r.id === reference.split('/')[1];
+      const referenceId = reference.split('/')[1];
+      return r.id === referenceId || (r.identifier && r.identifier.some(id => id.value === referenceId));;
     } else {
       return;
     }

--- a/extraction/index.js
+++ b/extraction/index.js
@@ -38,6 +38,7 @@ const createIcareWorkbook = () => {
   );
   treatmentPlanChangeWorksheet.columns = [
     {header: 'Effective Date', key: 'effectiveDate', width: 30},
+    {header: 'Changed Flag', key: 'changedFlag', width: 30},
     {header: 'Code Value', key: 'codeValue', width: 30},
     {header: 'Subject ID', key: 'subjectId', width: 30},
     {header: 'Trial ID', key: 'trialId', width: 30},
@@ -134,6 +135,7 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
     worksheet.addRow({
       ...trialData,
       effectiveDate,
+      changedFlag: (changedFlag.valueBoolean != null) ? `${changedFlag.valueBoolean}` : '',
       codeValue,
     });
   });

--- a/extraction/index.js
+++ b/extraction/index.js
@@ -64,12 +64,21 @@ const getDiseaseStatusResources = (bundle) => {
 // Retrieves condition resource by looking at id on reference
 const getConditionFromReference = (bundle, refArray) => {
   if (!(refArray && (refArray.length > 0))) return;
+  const reference = refArray[0];
   return getBundleResourcesByType(
       bundle,
       'Condition',
       {},
       false,
-  ).find((r) => r.id === refArray[0].split('/')[1]);
+  ).find((r) => {
+    if (reference.startsWith('urn:uuid:')) {
+      return r.id === reference.split(':')[2];
+    } else if (reference.includes('/')) {
+      return r.id === reference.split('/')[1];
+    } else {
+      return;
+    }
+  });
 };
 
 // Add Disease Status Resource to worksheet
@@ -119,7 +128,7 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
     const effectiveDate = reviewDate ? reviewDate.valueDate : '';
     const carePlanChangeReason = getExtensionByUrl(
       fhirpath.evaluate(resource, 'CarePlan.extension[0].extension'),
-      'CarePlanChangedReason',
+      'CarePlanChangeReason',
     );
     const changedFlag = getExtensionByUrl(
       fhirpath.evaluate(resource, 'CarePlan.extension[0].extension'),

--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -95,7 +95,7 @@ describe('Extraction', () => {
 
     expectedTpRow = {
       effectiveDate: '2020-02-23',
-      codeValue: 'not evaluated',
+      codeValue: '',
       subjectId: 'subjectId2',
       trialId: 'trialId2',
       siteId: 'siteId2',

--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -75,7 +75,7 @@ describe('Extraction', () => {
       expect(diseaseStatusWorksheet.columnCount).to.equal(8);
       expect(diseaseStatusWorksheet.rowCount).to.equal(1);
       expect(treatmentPlanChangeWorksheet).to.exist;
-      expect(treatmentPlanChangeWorksheet.columnCount).to.equal(5);
+      expect(treatmentPlanChangeWorksheet.columnCount).to.equal(6);
       expect(treatmentPlanChangeWorksheet.rowCount).to.equal(1);
       expect(workbook.getWorksheet('Test Worksheet')).to.not.exist;
     });
@@ -95,6 +95,7 @@ describe('Extraction', () => {
 
     expectedTpRow = {
       effectiveDate: '2020-02-23',
+      changedFlag: 'false',
       codeValue: '',
       subjectId: 'subjectId2',
       trialId: 'trialId2',
@@ -120,6 +121,7 @@ describe('Extraction', () => {
       expect(treatmentPlanChangeWorksheet.rowCount).to.equal(3);
       const tpRow = treatmentPlanChangeWorksheet.getRow(3);
       expect(tpRow.getCell('effectiveDate').text).to.equal(expectedTpRow.effectiveDate);
+      expect(tpRow.getCell('changedFlag').text).to.equal(expectedTpRow.changedFlag);
       expect(tpRow.getCell('codeValue').text).to.equal(expectedTpRow.codeValue);
       expect(tpRow.getCell('subjectId').text).to.equal(expectedTpRow.subjectId);
       expect(tpRow.getCell('trialId').text).to.equal(expectedTpRow.trialId);

--- a/test/fixtures/extraction/data.json
+++ b/test/fixtures/extraction/data.json
@@ -143,7 +143,7 @@
                                               "valueDate": "2020-01-23"
                                           },
                                           {
-                                              "url": "CarePlanChangedReason",
+                                              "url": "CarePlanChangeReason",
                                               "valueCodeableConcept": {
                                                   "coding": [
                                                       {

--- a/test/fixtures/messaging/exampleR4Message.json
+++ b/test/fixtures/messaging/exampleR4Message.json
@@ -346,7 +346,7 @@
                       "valueDate": "2020-01-23"
                     },
                     {
-                      "url": "CarePlanChangedReason",
+                      "url": "CarePlanChangeReason",
                       "valueCodeableConcept": {
                         "coding": [
                           {

--- a/utils/fhirUtils.js
+++ b/utils/fhirUtils.js
@@ -17,7 +17,7 @@ const getBundleResourcesByType = (message, type, context = {}, first) => {
 };
 
 const getExtensionByUrl = (extArr, url) => {
-  return extArr.find((e) => e.url === url);
+  return extArr ? extArr.find((e) => e.url === url) : undefined;
 };
 
 module.exports = {

--- a/utils/fhirUtils.js
+++ b/utils/fhirUtils.js
@@ -16,11 +16,19 @@ const getBundleResourcesByType = (message, type, context = {}, first) => {
   }
 };
 
-const getExtensionByUrl = (extArr, url) => {
-  return extArr ? extArr.find((e) => e.url === url) : undefined;
+// Utility function to get the extensions on an array of extension by url
+// Optionally get only the first extension of that url via 'first' parameter
+const getExtensionsByUrl = (extArr, url, first) => {
+  const extensions = extArr ? extArr.filter((e) => e.url === url) : [];
+
+  if (extensions.length > 0) {
+    return first ? extensions[0] : extensions;
+  } else {
+    return first ? null : [];
+  }
 };
 
 module.exports = {
   getBundleResourcesByType,
-  getExtensionByUrl,
+  getExtensionsByUrl,
 };

--- a/utils/fhirUtils.js
+++ b/utils/fhirUtils.js
@@ -2,7 +2,7 @@ const fhirpath = require('fhirpath');
 
 // Utility function to get the resources of a type from our message bundle
 // Optionally get only the first resource of that type via 'first' parameter
-const getBundleResourcesByType = (message, type, context = {}, first) => {
+const getBundleResourcesByType = (message, type, context = {}, first=false) => {
   const resources = fhirpath.evaluate(
       message,
       `Bundle.entry.where(resource.resourceType='${type}').resource`,
@@ -18,7 +18,7 @@ const getBundleResourcesByType = (message, type, context = {}, first) => {
 
 // Utility function to get the extensions on an array of extension by url
 // Optionally get only the first extension of that url via 'first' parameter
-const getExtensionsByUrl = (extArr, url, first) => {
+const getExtensionsByUrl = (extArr, url, first=false) => {
   const extensions = extArr ? extArr.filter((e) => e.url === url) : [];
 
   if (extensions.length > 0) {
@@ -28,7 +28,24 @@ const getExtensionsByUrl = (extArr, url, first) => {
   }
 };
 
+// Utility function to return a boolean indicating whether a given resource id
+// matches the given reference id
+const doResourceAndReferenceIdsMatch = (resource, reference) => {
+  if (reference.startsWith('urn:uuid:')) {
+    const referenceId = reference.split(':')[2];
+    return resource.id === referenceId ||
+      (resource.identifier && resource.identifier.some((id) => id.value === referenceId));
+  } else if (reference.includes('/')) {
+    const referenceId = reference.split('/')[1];
+    return resource.id === referenceId ||
+      (resource.identifier && resource.identifier.some((id) => id.value === referenceId));
+  } else {
+    return false;
+  }
+};
+
 module.exports = {
   getBundleResourcesByType,
   getExtensionsByUrl,
+  doResourceAndReferenceIdsMatch,
 };


### PR DESCRIPTION
I'd like two reviewers on this, and preferable one of them is @rdingwell so we can make sure all looks good according to his assessment.

Previously, we had errors in the data extraction lambda that caused some crashes on entries in the database that had incomplete or invalid data. This PR fixes the issues that caused those crashes, and defaults to pushing incomplete columns to S3 without crashing if need be.

To test this, run the data extraction lambda in the dev AWS environment with an empty test event, and verify that it runs properly without crashing. Then, download the .zip file you created in S3 and verify that its contents look reasonable. You should see that there is a row for each element, and there is simply an empty cell for any row that doesn't have data for that column.

Also, run `yarn test` to make sure those work.

~One thing I noticed is that my most recent data posted using the CSV client didn't have a Cancer Code Value or Cancer Type for Disease Status, or a Code Value for Treatment Plan Change. I want to make sure that we would expect that to be the case. I'm confident that these columns in the lambda work, since some rows have this data. Just don't know why we wouldn't have those columns filled in our most recent data.~