### PR TITLE
Add log statements to extraction lambda

### DIFF
--- a/extraction/index.js
+++ b/extraction/index.js
@@ -130,8 +130,6 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
       false,
   );
   carePlanResources.forEach((resource) => {
-    const resourceId = fhirpath.evaluate(resource, 'CarePlan.id')[0];
-
     const reviewExtensionUrl = 'http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review';
     const reviewExtension = fhirpath.evaluate(
         resource,
@@ -147,15 +145,15 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
       '';
 
     if (!reviewDate) {
-      console.log(`No ReviewDate was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+      console.log(`No ReviewDate was found on Bundle ${bundleId}.`);
     }
 
     if (!changedFlag) {
-      console.log(`No ChangedFlag was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+      console.log(`No ChangedFlag was found on Bundle ${bundleId}.`);
     }
 
     if (changedFlag && changedFlag.valueBoolean && !carePlanChangeReason) {
-      console.log(`No CarePlanChangeReason was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+      console.log(`No CarePlanChangeReason was found on Bundle ${bundleId}.`);
     }
 
     worksheet.addRow({

--- a/extraction/index.js
+++ b/extraction/index.js
@@ -80,12 +80,18 @@ const getConditionFromFocusReference = (bundle, focuses) => {
 
 // Add Disease Status Resource to worksheet
 const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
+  const bundleId = fhirpath.evaluate(bundle, 'Bundle.id')[0];
+
   const dsResources = getDiseaseStatusResources(bundle);
   dsResources.forEach((resource) => {
     const evidenceExtensions = getExtensionsByUrl(
         fhirpath.evaluate(resource, 'Observation.extension'),
         'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type',
     );
+
+    if (evidenceExtensions.length === 0) {
+      console.log(`No evidence extensions were found on Bundle ${bundleId}.`);
+    }
 
     // Joins the array of evidence items
     const evidence = evidenceExtensions.map((extension) => {
@@ -96,6 +102,10 @@ const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
         bundle,
         fhirpath.evaluate(resource, 'Observation.focus'),
     );
+
+    if (!condition) {
+      console.log(`No Condition was found by reference on Bundle ${bundleId}.`);
+    }
 
     worksheet.addRow({
       ...trialData,
@@ -110,6 +120,8 @@ const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
 
 // Add Careplan resources to worksheet
 const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
+  const bundleId = fhirpath.evaluate(bundle, 'Bundle.id')[0];
+
   // Get CarePlan Resources and add data to worksheet
   const carePlanResources = getBundleResourcesByType(
       bundle,
@@ -118,6 +130,8 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
       false,
   );
   carePlanResources.forEach((resource) => {
+    const resourceId = fhirpath.evaluate(resource, 'CarePlan.id')[0];
+
     const reviewExtensionUrl = 'http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review';
     const reviewExtension = fhirpath.evaluate(
         resource,
@@ -131,6 +145,18 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
     const codeValue = changedFlag.valueBoolean && carePlanChangeReason ?
       translateCode(carePlanChangeReason.valueCodeableConcept) :
       '';
+
+    if (!reviewDate) {
+      console.log(`No ReviewDate was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+    }
+
+    if (!changedFlag) {
+      console.log(`No ChangedFlag was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+    }
+
+    if (changedFlag && changedFlag.valueBoolean && !carePlanChangeReason) {
+      console.log(`No CarePlanChangeReason was found on CarePlan ${resourceId} on Bundle ${bundleId}.`);
+    }
 
     worksheet.addRow({
       ...trialData,


### PR DESCRIPTION
Adds log statements to some relevant potential missing resources/extensions in the extraction lambda. Doesn't affect any other code other than the log output.

If you run this lambda against the database as-is (I've uploaded it), you should see some log statements in CloudWatch indicating these errors, since some records in the database do have these things empty. If you run it with a more recent siteId using records processed from STEAM, you should not see any logged errors.