### PR TITLE
Change Conformance to CapabilityStatement and update accordingly

### DIFF
--- a/conformance/index.js
+++ b/conformance/index.js
@@ -4,7 +4,7 @@ const capabilityStatement = {
   'version': '1.0.0',
   'status': 'active',
   'experimental': true,
-  'date': '2020-09-11',
+  'date': '2020-09-14',
   'kind': 'capability',
   'fhirVersion': '4.0.1',
   'format': [

--- a/conformance/index.js
+++ b/conformance/index.js
@@ -1,17 +1,17 @@
-const conformanceStatement = {
-  'resourceType': 'Conformance',
+const capabilityStatement = {
+  'resourceType': 'CapabilityStatement',
   'url': process.env.METADATA_URL || 'https://testing.icaredata.org/metadata',
-  'version': '0.0.0',
+  'version': '1.0.0',
+  'status': 'draft',
   'experimental': true,
-  'date': '2019-10-29',
+  'date': '2020-09-11',
   'kind': 'capability',
   'fhirVersion': '4.0.0',
-  'acceptUnknown': 'no',
   'format': [
     'application/json+fhir',
   ],
 };
 
 exports.handler = async () => {
-  return conformanceStatement;
+  return capabilityStatement;
 };

--- a/conformance/index.js
+++ b/conformance/index.js
@@ -2,11 +2,11 @@ const capabilityStatement = {
   'resourceType': 'CapabilityStatement',
   'url': process.env.METADATA_URL || 'https://testing.icaredata.org/metadata',
   'version': '1.0.0',
-  'status': 'draft',
+  'status': 'active',
   'experimental': true,
   'date': '2020-09-11',
   'kind': 'capability',
-  'fhirVersion': '4.0.0',
+  'fhirVersion': '4.0.1',
   'format': [
     'application/json+fhir',
   ],

--- a/test/conformance.test.js
+++ b/test/conformance.test.js
@@ -5,7 +5,7 @@ describe('Metadata', async () => {
   describe('handler', async () => {
     it('Should return a FHIR conformance statement', async () => {
       const response = await handler();
-      expect(response.resourceType).to.equal('Conformance');
+      expect(response.resourceType).to.equal('CapabilityStatement');
       expect(response.format).to.contain('application/json+fhir');
     });
   });


### PR DESCRIPTION
We needed to update the `Conformance` to be a `CapabilityStatement` in accordance with FHIR R4, per the following link: https://www.hl7.org/fhir/capabilitystatement.html

I believe that I've done this correctly but would like at least two quick reviews to make sure this seems correct. A few notes on some changes I'm not 100% sure about below.

1. Should the `status` be `active` since I guess technically we're ready for production now?
2. Is `4.0.0` the version we're really targeting or is it `4.0.1`?
3. Are we still `experimental`, and if not, should I set it to `false` or should I just remove the field?