### PR TITLE
Extraction Lambda Null Checks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 The MITRE Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,27 +3,10 @@
 The `icaredata-platform` repository contains the code for the AWS Lambda functions for the ICAREdata infrastructure.
 ## Install Dependencies  
 
-The following instructions assume a MacOS development setup.
-
-Install the [Homebrew](https://brew.sh/) package manager.
-
-Use Homebrew in the command line to install `node` and `yarn`.
+Use `npm` to install dependencies.
 
 ```bash
-brew install node
-brew install yarn
-```
-
-After installing these, `yarn` can be used to install all required dependencies for the code in this repository.
-
-```bash
-yarn install
-```
-
-Finally, install Terraform, an automated build and deployment tool for AWS resources.
-
-```bash
-brew install terraform
+npm install
 ```
 
 ## Run the Test Suite
@@ -33,7 +16,7 @@ brew install terraform
 To run the test suite for this repository, run the following command.
 
 ```bash
-yarn test
+npm test
 ```
 
 ## Deploying to AWS

--- a/extraction/index.js
+++ b/extraction/index.js
@@ -52,7 +52,7 @@ const createIcareWorkbook = () => {
 // If there are multiple codes, will join them and delimit with |
 const translateCode = (codeObject) => {
   return (codeObject && codeObject.coding) ?
-    codeObject.coding.map((c) => `${c.system} : ${c.code}`).join(' | ') :
+    codeObject.coding.filter((c) => c).map((c) => `${c.system} : ${c.code}`).join(' | ') :
     '';
 };
 
@@ -63,7 +63,7 @@ const getDiseaseStatusResources = (bundle) => {
       'Observation',
       {},
       false,
-  ).filter((r) => r.code && r.code.coding.some((c) => c.system === 'http://loinc.org' && c.code === '88040-1'));
+  ).filter((r) => r.code && r.code.coding.filter((c) => c).some((c) => c.system === 'http://loinc.org' && c.code === '88040-1'));
 };
 
 // Retrieves condition resource by looking at ids and identifiers on focus reference

--- a/utils/conditionUtils.js
+++ b/utils/conditionUtils.js
@@ -14,6 +14,7 @@ const checkCodeInVS = (condition, valueSet) => {
   if (valueSet.expansion) {
     return coding.some((c) => {
       return valueSet.expansion.contains.some((containsItem) => {
+        if (!c || !containsItem) return false;
         return c.system === containsItem.system && c.code === containsItem.code;
       });
     });
@@ -22,7 +23,7 @@ const checkCodeInVS = (condition, valueSet) => {
   // Checks if code is in any of the valueSet.compose.include arrays
   return coding.some((c) => {
     return valueSet.compose.include.some((includeItem) => {
-      if (!includeItem.concept) return false;
+      if (!c || !includeItem || !includeItem.concept) return false;
       return c.system === includeItem.system &&
         includeItem.concept.map((concept) => concept.code).includes(c.code);
     });


### PR DESCRIPTION
There were some extraneous errors existing in the extraction lambda and some of its utils that caused crashes when running it. This resolves those issues. It also fixes some outdated references to `yarn` in the README.

@julianxcarter and I have manually tested this in the infrastructure already, so there's no need for further testing of that needed. Simply run the tests and lint and that should be all that's necessary.