### PR TITLE
Multiple CarePlan Extensions 

### DIFF
--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -2,12 +2,14 @@ const {expect} = require('chai');
 const rewire = require('rewire');
 const extraction = rewire('../extraction');
 const data = require('./fixtures/extraction/data.json');
+const treatmentPlanChangeData = require('./fixtures/extraction/carePlanResources.json');
 
 // helpers from extraction/index.js
 const createIcareWorkbook = extraction.__get__('createIcareWorkbook');
 const translateCode = extraction.__get__('translateCode');
 const getDiseaseStatusResources = extraction.__get__('getDiseaseStatusResources');
 const processData = extraction.__get__('processData');
+const getCarePlanDataFromExtensions = extraction.__get__('getCarePlanDataFromExtensions');
 
 describe('Extraction', () => {
   describe('translateCode', () => {
@@ -117,15 +119,36 @@ describe('Extraction', () => {
       expect(dsRow.getCell('trialId').text).to.equal(expectedDsRow.trialId);
       expect(dsRow.getCell('siteId').text).to.equal(expectedDsRow.siteId);
 
-      // Header + 1 careplan from each bundle
-      expect(treatmentPlanChangeWorksheet.rowCount).to.equal(3);
-      const tpRow = treatmentPlanChangeWorksheet.getRow(3);
+      // Header + 1 careplan extension from each bundle
+      expect(treatmentPlanChangeWorksheet.rowCount).to.equal(4);
+      const tpRow = treatmentPlanChangeWorksheet.getRow(4);
       expect(tpRow.getCell('effectiveDate').text).to.equal(expectedTpRow.effectiveDate);
       expect(tpRow.getCell('changedFlag').text).to.equal(expectedTpRow.changedFlag);
       expect(tpRow.getCell('codeValue').text).to.equal(expectedTpRow.codeValue);
       expect(tpRow.getCell('subjectId').text).to.equal(expectedTpRow.subjectId);
       expect(tpRow.getCell('trialId').text).to.equal(expectedTpRow.trialId);
       expect(tpRow.getCell('siteId').text).to.equal(expectedTpRow.siteId);
+    });
+  });
+
+  describe('getCarePlanDataFromExtensions', () => {
+    it('gets proper list of extension entries', () => {
+      const expectedReturn = [
+        {
+          effectiveDate: '2020-03-23',
+          changedFlag: 'true',
+          codeValue: 'http://snomed.info/sct : 281647001',
+        },
+        {
+          effectiveDate: '2020-02-23',
+          changedFlag: 'false',
+          codeValue: '',
+        },
+      ];
+
+      const extensionData = getCarePlanDataFromExtensions(treatmentPlanChangeData, '');
+
+      expect(extensionData).to.deep.equal(expectedReturn);
     });
   });
 });

--- a/test/fixtures/extraction/carePlanResources.json
+++ b/test/fixtures/extraction/carePlanResources.json
@@ -1,0 +1,42 @@
+{
+   "resourceType": "CarePlan",
+   "extension": [
+      {
+         "url": "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review",
+         "extension": [
+            {
+               "url": "CarePlanChangeReason",
+               "valueCodeableConcept": {
+                  "coding": [
+                     {
+                        "system": "http://snomed.info/sct",
+                        "code": "281647001"
+                     }
+                  ]
+               }
+            },
+            {
+               "url": "ChangedFlag",
+               "valueBoolean": true
+            },
+            {
+               "url": "ReviewDate",
+               "valueDate": "2020-03-23"
+            }
+         ]
+      },
+      {
+         "url": "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review",
+         "extension": [
+            {
+               "url": "ChangedFlag",
+               "valueBoolean": false
+            },
+            {
+               "url": "ReviewDate",
+               "valueDate": "2020-02-23"
+            }
+         ]
+      }
+   ]
+}

--- a/test/fixtures/extraction/data.json
+++ b/test/fixtures/extraction/data.json
@@ -154,6 +154,19 @@
                                                     }
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "url": "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review",
+                                            "extension": [
+                                                {
+                                                    "url": "ChangedFlag",
+                                                    "valueBoolean": false
+                                                },
+                                                {
+                                                    "url": "ReviewDate",
+                                                    "valueDate": "2020-02-23"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Update the treatment plan change parsing of the extraction lambda to iterate through every extension entry.

* Adds a helper function for returning a mapped array of each data entry in each extension array for a given CarePlan resource
* Code now calls this helper for each CarePlan resource and adds a row for each entry
* Add unit tests

See https://github.com/mcode/base-icare-extraction-client/pull/24 for a branch to post data to AWS that adheres to the new CarePlan format.

Running the data extraction lambda should now generate a CSV with a row for each entry in a given CarePlan's extension. If you want to post new data with multiple extensions, use the base icare client and add a row to the CSV like follows:

``` csv
mrn,reasonCode,changed,dateOfCarePlan,dateRecorded
123,281647001,true,2020-04-15,2020-04-15
123,281647001,false,2020-04-30,2020-04-30
456,405613005,true,2020-03-30,2020-04-15
789,266721009,true,2020-04-22,2020-06-17
```

The two rows for the 123 patient will now generate 2 extensions in 1 CarePlan resource. After posting this and running the data extraction lambda, you should now see a row in the resulting spreadsheet for each of these.

I recommend testing with a unique site-id first to start with a clean slate before running the lambda on everything in the database.