### PR TITLE
Not Evaluated code handling on CDS resources

### DIFF
--- a/extraction/index.js
+++ b/extraction/index.js
@@ -113,7 +113,9 @@ const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
       effectiveDate: resource.effectiveDateTime,
       cancerType: condition ? getCancerType(condition) : '',
       cancerCodeValue: condition ? translateCode(condition.code) : '',
-      codeValue: translateCode(resource.valueCodeableConcept),
+      codeValue: resource.valueCodeableConcept.extension && resource.valueCodeableConcept.extension.some((e) => e.valueCode === 'not-asked') ?
+        'not-asked' :
+        translateCode(resource.valueCodeableConcept),
     });
   });
 };

--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -119,6 +119,10 @@ describe('Extraction', () => {
       expect(dsRow.getCell('trialId').text).to.equal(expectedDsRow.trialId);
       expect(dsRow.getCell('siteId').text).to.equal(expectedDsRow.siteId);
 
+      // A disease status bundle with a dataAbsentReason extension should have 'not-asked' in it's codeValue field
+      const dsNotAskedRow = diseaseStatusWorksheet.getRow(4);
+      expect(dsNotAskedRow.getCell('codeValue').text).to.equal('not-asked');
+
       // Header + 1 careplan extension from each bundle
       expect(treatmentPlanChangeWorksheet.rowCount).to.equal(4);
       const tpRow = treatmentPlanChangeWorksheet.getRow(4);

--- a/test/fixtures/extraction/data.json
+++ b/test/fixtures/extraction/data.json
@@ -221,12 +221,12 @@
                                     ],
                                     "effectiveDateTime": "2019-04-01",
                                     "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://snomed.info/sct",
-                                                "code": "268910001"
-                                            }
-                                        ]
+                                      "extension": [
+                                        {
+                                          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                          "valueCode": "not-asked"
+                                        }
+                                      ]
                                     }
                                 }
                             },


### PR DESCRIPTION
This PR simply updates the `addDiseaseStatusToWorksheet` function within the extraction lambda to recognize when a `dataAbsentReason` extension has been added to a Cancer Disease Status bundle. If the dataAbsentReason extension is found in the `valueCodeableConcept` object, then a value of `not-asked` is added to the `codeValue` field on that disease status's row on the excel sheet. 

We'll likely test this together in the working session, however in the mean time reviewers can ensure that the small addition to `extraction.test.js` makes sense and also that the PR seems to accomplish its goal. 