### PR TITLE
Changing duplicate checking to avoid empty rows

### DIFF
--- a/extraction/index.js
+++ b/extraction/index.js
@@ -108,7 +108,7 @@ const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
       console.log(`No Condition was found by reference on Bundle ${bundleId}.`);
     }
 
-    worksheet.addRow({
+    const newRow = {
       ...trialData,
       evidence,
       effectiveDate: resource.effectiveDateTime,
@@ -117,14 +117,16 @@ const addDiseaseStatusDataToWorksheet = (bundle, worksheet, trialData) => {
       codeValue: resource.valueCodeableConcept && resource.valueCodeableConcept.extension && resource.valueCodeableConcept.extension.some((e) => e.valueCode === 'not-asked') ?
         'not-asked' :
         translateCode(resource.valueCodeableConcept),
-    });
-    const newRow = worksheet.getRow(worksheet.rowCount).values;
-    for (let i = 1; i < worksheet.rowCount; i++) {
-      if (_.isEqual(newRow, worksheet.getRow(i).values)) {
-        worksheet.spliceRows(worksheet.rowCount, 1, []);
+    };
+    const newRowValues = worksheet.columns.map((col) => newRow[col.key]);
+    let duplicate = false;
+    for (let i = 1; i < worksheet.rowCount+1; i++) {
+      if (_.isEqual(newRowValues, worksheet.getRow(i).values.slice(1))) {
+        duplicate = true;
         break;
       }
     }
+    if (!duplicate) worksheet.addRow(newRow);
   });
 };
 
@@ -181,17 +183,19 @@ const addCarePlanDataToWorksheet = (bundle, worksheet, trialData) => {
     const extensionData = getCarePlanDataFromExtensions(resource, bundleId);
 
     extensionData.forEach((d) => {
-      worksheet.addRow({
+      const newRow = {
         ...trialData,
         ...d,
-      });
-      const newRow = worksheet.getRow(worksheet.rowCount).values;
-      for (let i = 1; i < worksheet.rowCount; i++) {
-        if (_.isEqual(newRow, worksheet.getRow(i).values)) {
-          worksheet.spliceRows(worksheet.rowCount, 1, []);
+      };
+      const newRowValues = worksheet.columns.map((col) => newRow[col.key]);
+      let duplicate = false;
+      for (let i = 1; i < worksheet.rowCount+1; i++) {
+        if (_.isEqual(newRowValues, worksheet.getRow(i).values.splice(1))) {
+          duplicate = true;
           break;
         }
       }
+      if (!duplicate) worksheet.addRow(newRow);
     });
   });
 };


### PR DESCRIPTION
This PR changes the method of checking for duplicate rows, which was causing extra empty rows in the excel spreadsheet output. Previously, a new row would be added to the sheet and then deleted if it was a duplicate, leaving an empty row, now we check if the row is a duplicate before adding it to the sheet and only add it if it isn't a duplicate. 

To test, run the ICARE client twice with the same config and then run the extraction lambda and check that the resulting excel sheet does not have duplicates and does not have empty rows