### PR TITLE
Support extraction of adverse event resources in new worksheet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @rdingwell @jafeltra @mgramigna @julianxcarter @dmendelowitz @dtphelan1
+*   @rdingwell @dmendelowitz @dtphelan1

--- a/extraction/index.js
+++ b/extraction/index.js
@@ -298,7 +298,7 @@ const getAdverseEventDataFromExtensions = (adverseEventResource, bundleId) => {
     'http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-resolved-date';
   const seriousnessOutcomeUrl =
     'http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-seriousness-outcome';
-  const grade = getExtensionsByUrl(
+  const adverseEventGrade = getExtensionsByUrl(
     adverseEventResourceExtension,
     gradeUrl,
     true
@@ -313,7 +313,7 @@ const getAdverseEventDataFromExtensions = (adverseEventResource, bundleId) => {
     seriousnessOutcomeUrl,
     true
   );
-  if (!grade) {
+  if (!adverseEventGrade) {
     console.log(`No grade extension was found on Bundle ${bundleId}`);
   }
   if (!resolvedDate) {
@@ -325,10 +325,13 @@ const getAdverseEventDataFromExtensions = (adverseEventResource, bundleId) => {
     );
   }
   return {
-    grade: grade && translateCode(grade.value),
-    resolvedDate: resolvedDate && translateCode(resolvedDate.valueDateTime),
+    resolvedDate: resolvedDate && resolvedDate.valueDateTime,
+    adverseEventGrade:
+      adverseEventGrade &&
+      translateCode(adverseEventGrade.valueCodeableConcept),
     seriousnessOutcome:
-      seriousnessOutcome && translateCode(seriousnessOutcome.value),
+      seriousnessOutcome &&
+      translateCode(seriousnessOutcome.valueCodeableConcept),
   };
 };
 
@@ -350,7 +353,7 @@ const addAdverseEventDataToWorksheet = (bundle, worksheet, trialData) => {
 
   adverseEventResources.forEach((resource) => {
     // All data from extensions
-    const { grade, resolvedDate, seriousnessOutcome } =
+    const { adverseEventGrade, resolvedDate, seriousnessOutcome } =
       getAdverseEventDataFromExtensions(resource, bundleId);
 
     // AdverseEvent data is a CodeableConcept
@@ -393,7 +396,7 @@ const addAdverseEventDataToWorksheet = (bundle, worksheet, trialData) => {
     // const trialData = { subjectId, trialId, siteId, submissionDate, bundleId };
     const newAdverseEventRow = {
       ...trialData,
-      grade,
+      adverseEventGrade,
       adverseEventCode,
       suspectedCause,
       suspectedCauseAssessments,

--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -184,7 +184,6 @@ describe('Extraction', () => {
       expect(dsNotAskedRow.getCell('codeValue').text).to.equal('not-asked');
     });
     it('adds rows to treatment plan change worksheet', () => {
-      // > CarePlan Checks
       // Header + 1 careplan extension from each bundle
       expect(treatmentPlanChangeWorksheet.rowCount).to.equal(4);
       const tpRow = treatmentPlanChangeWorksheet.getRow(4);
@@ -200,7 +199,6 @@ describe('Extraction', () => {
       expect(tpRow.getCell('siteId').text).to.equal(expectedTpRow.siteId);
     });
     it('adds rows to adverse events worksheet', () => {
-      // > AdverseEvent Checks
       // Header + 1 AE from the first bundle only
       expect(adverseEventWorksheet.rowCount).to.equal(2);
       const aeRow = adverseEventWorksheet.getRow(2);

--- a/test/extraction.test.js
+++ b/test/extraction.test.js
@@ -99,7 +99,7 @@ describe('Extraction', () => {
     });
     it('creates workbook with Adverse Event worksheets', () => {
       expect(adverseEventWorksheet).to.exist;
-      expect(adverseEventWorksheet.columnCount).to.equal(13);
+      expect(adverseEventWorksheet.columnCount).to.equal(17);
       expect(adverseEventWorksheet.rowCount).to.equal(1);
     });
     it('does not create workbook with an unexpected worksheet', () => {
@@ -136,20 +136,25 @@ describe('Extraction', () => {
     const expectedAeRow = {
       submissionDate: '2019-04-01',
       bundleId: '1',
+      adverseEventGrade:
+        '2 : http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system',
       adverseEventCode: 'code-system : 109006',
       suspectedCause: 'Procedure : urn:uuid:procedure-id',
       seriousnessCode:
         'http://terminology.hl7.org/CodeSystem/adverse-event-seriousness : serious',
       categoryCode:
         'http://terminology.hl7.org/CodeSystem/adverse-event-category : product-use-error',
-      severityCode:
-        'http://terminology.hl7.org/CodeSystem/adverse-event-severity : severe',
       actuality: 'actual',
       effectiveDate: '1994-12-09',
       recordedDate: '1994-12-09',
       subjectId: 'subjectId1',
       trialId: 'trialId1',
       siteId: 'siteId1',
+      seriousnessOutcome:
+        'C113380 : http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl',
+      resolvedDate: '2021-12-09',
+      suspectedCauseAssessments: '',
+      outcomeCode: '',
     };
 
     // Process data should have side effects
@@ -217,9 +222,6 @@ describe('Extraction', () => {
       );
       expect(aeRow.getCell('categoryCode').text).to.equal(
         expectedAeRow.categoryCode
-      );
-      expect(aeRow.getCell('severityCode').text).to.equal(
-        expectedAeRow.severityCode
       );
       expect(aeRow.getCell('actuality').text).to.equal(expectedAeRow.actuality);
       expect(aeRow.getCell('effectiveDate').text).to.equal(

--- a/test/fixtures/extraction/data.json
+++ b/test/fixtures/extraction/data.json
@@ -170,12 +170,73 @@
                     }
                   ]
                 }
+              },
+              {
+                "resource": {
+                  "resourceType": "AdverseEvent",
+                  "id": "adverseEventId-1",
+                  "event": {
+                    "coding": [
+                      {
+                        "system": "code-system",
+                        "code": "109006",
+                        "display": "Anxiety disorder of childhood OR adolescence"
+                      }
+                    ]
+                  },
+                  "suspectEntity": [
+                    {
+                      "instance": {
+                        "reference": "urn:uuid:procedure-id",
+                        "type": "Procedure"
+                      }
+                    }
+                  ],
+                  "seriousness": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/adverse-event-seriousness",
+                        "code": "serious",
+                        "display": "Serious"
+                      }
+                    ]
+                  },
+                  "category": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://terminology.hl7.org/CodeSystem/adverse-event-category",
+                          "code": "product-use-error",
+                          "display": "Product Use Error"
+                        }
+                      ]
+                    }
+                  ],
+                  "severity": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/adverse-event-severity",
+                        "code": "severe"
+                      }
+                    ]
+                  },
+                  "actuality": "actual",
+                  "study": [
+                    {
+                      "reference": "urn:uuid:researchId-1",
+                      "type": "ResearchStudy"
+                    }
+                  ],
+                  "date": "1994-12-09",
+                  "recordedDate": "1994-12-09"
+                }
               }
             ]
           }
         }
       ]
     },
+    "submission_time": "2019-04-01",
     "subject_id": "subjectId1",
     "trial_id": "trialId1",
     "site_id": "siteId1"

--- a/test/fixtures/extraction/data.json
+++ b/test/fixtures/extraction/data.json
@@ -175,14 +175,85 @@
                 "resource": {
                   "resourceType": "AdverseEvent",
                   "id": "adverseEventId-1",
+                  "subject": {
+                    "reference": "urn:uuid:mrn-1",
+                    "type": "Patient"
+                  },
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/ctcae/StructureDefinition/ctcae-grade",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/us/ctcae/CodeSystem/ctcae-grade-code-system",
+                            "code": "2",
+                            "display": "Moderate Adverse Event"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-resolved-date",
+                      "valueDateTime": "2021-12-09"
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-expectation",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                            "code": "C41333",
+                            "display": "Expected Adverse Event"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-seriousness-outcome",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+                            "code": "C113380",
+                            "display": "Disabling Adverse Event"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/ctcae/StructureDefinition/adverse-event-participant",
+                      "extension": [
+                        {
+                          "url": "function",
+                          "valueCodeableConcept": {
+                            "coding": [
+                              {
+                                "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                "code": "PART",
+                                "display": "Participation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "url": "actor",
+                          "valueReference": {
+                            "reference": "urn:uuid:practitioner-id"
+                          }
+                        }
+                      ]
+                    }
+                  ],
                   "event": {
                     "coding": [
                       {
                         "system": "code-system",
                         "code": "109006",
+                        "version": "code-version",
                         "display": "Anxiety disorder of childhood OR adolescence"
                       }
-                    ]
+                    ],
+                    "text": "event-text"
                   },
                   "suspectEntity": [
                     {
@@ -212,14 +283,6 @@
                       ]
                     }
                   ],
-                  "severity": {
-                    "coding": [
-                      {
-                        "system": "http://terminology.hl7.org/CodeSystem/adverse-event-severity",
-                        "code": "severe"
-                      }
-                    ]
-                  },
                   "actuality": "actual",
                   "study": [
                     {


### PR DESCRIPTION
In addition to supporting this new resource in our extraction lambda, this PR makes minor modifications to our test file for easier debugging and readability. Some notable but small changes
- Defining a global ARRAYJOINDELIMITER value which is used for joining all array-values
- Better descriptions of what each it('') test-block is doing 
- More granular it('') test-blocks for better debugging in the event of test errors
- Cloning of early worksheet views to avoid race conditions with later processing of data and updating of rows
- Adding AE data to one of the bundles on our fixture. 